### PR TITLE
Inherit from Print class

### DIFF
--- a/examples/Demo/Demo.ino
+++ b/examples/Demo/Demo.ino
@@ -52,4 +52,10 @@ void setup() {
 }
 
 void loop() {
+    delay(2000);
+    
+    WebSerial.print(F("IP address: "));
+    WebSerial.println(WiFi.localIP());
+    WebSerial.printf("Millis=%d\n", millis());
+    WebSerial.printf("Free heap=[%d]\n", ESP.getFreeHeap());
 }

--- a/examples/Demo/Demo.ino
+++ b/examples/Demo/Demo.ino
@@ -57,5 +57,5 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
     WebSerial.printf("Millis=%lu\n", millis());
-    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap=[%u]\n", ESP.getFreeHeap());
 }

--- a/examples/Demo/Demo.ino
+++ b/examples/Demo/Demo.ino
@@ -56,6 +56,6 @@ void loop() {
     
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
-    WebSerial.printf("Millis=%d\n", millis());
-    WebSerial.printf("Free heap=[%d]\n", ESP.getFreeHeap());
+    WebSerial.printf("Millis=%lu\n", millis());
+    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
 }

--- a/examples/Demo_AP/Demo_AP.ino
+++ b/examples/Demo_AP/Demo_AP.ino
@@ -54,6 +54,6 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
     WebSerial.printf("Millis=%lu\n", millis());
-    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap=[%u]\n", ESP.getFreeHeap());
 
 }

--- a/examples/Demo_AP/Demo_AP.ino
+++ b/examples/Demo_AP/Demo_AP.ino
@@ -49,4 +49,11 @@ void setup() {
 }
 
 void loop() {
+    delay(2000);
+    
+    WebSerial.print(F("IP address: "));
+    WebSerial.println(WiFi.localIP());
+    WebSerial.printf("Millis=%d\n", millis());
+    WebSerial.printf("Free heap=[%d]\n", ESP.getFreeHeap());
+
 }

--- a/examples/Demo_AP/Demo_AP.ino
+++ b/examples/Demo_AP/Demo_AP.ino
@@ -53,7 +53,7 @@ void loop() {
     
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
-    WebSerial.printf("Millis=%d\n", millis());
-    WebSerial.printf("Free heap=[%d]\n", ESP.getFreeHeap());
+    WebSerial.printf("Millis=%lu\n", millis());
+    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
 
 }

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -43,79 +43,14 @@ void WebSerialClass::msgCallback(RecvMsgHandler _recv){
 }
 
 // Print
-void WebSerialClass::print(String m){
-    _ws->textAll(m);
+size_t WebSerialClass::write(uint8_t m) {
+  _ws->textAll((const char *)&(m), 1);
+  return(1);
 }
 
-void WebSerialClass::print(const char *m){
-    _ws->textAll(m);
-}
-
-void WebSerialClass::print(char *m){
-    _ws->textAll(m);
-}
-
-void WebSerialClass::print(int m){
-    _ws->textAll(String(m));
-}
-
-void WebSerialClass::print(uint8_t m){
-    _ws->textAll(String(m));
-}
-
-void WebSerialClass::print(uint16_t m){
-    _ws->textAll(String(m));
-}
-
-void WebSerialClass::print(uint32_t m){
-    _ws->textAll(String(m));
-}
-
-void WebSerialClass::print(double m){
-    _ws->textAll(String(m));
-}
-
-void WebSerialClass::print(float m){
-    _ws->textAll(String(m));
-}
-
-
-// Print with New Line
-
-void WebSerialClass::println(String m){
-    _ws->textAll(m+"\n");        
-}
-
-void WebSerialClass::println(const char *m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(char *m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(int m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(uint8_t m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(uint16_t m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(uint32_t m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(float m){
-    _ws->textAll(String(m)+"\n");
-}
-
-void WebSerialClass::println(double m){
-    _ws->textAll(String(m)+"\n");
+size_t WebSerialClass::write(const uint8_t* buffer, size_t size) {
+  _ws->textAll((const char *)buffer, size);
+  return(size);
 }
 
 #if defined(WEBSERIAL_DEBUG)

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -24,7 +24,7 @@ typedef std::function<void(uint8_t *data, size_t len)> RecvMsgHandler;
 // Uncomment to enable webserial debug mode
 // #define WEBSERIAL_DEBUG 1
 
-class WebSerialClass{
+class WebSerialClass : public Print {
 
 public:
     void begin(AsyncWebServer *server, const char* url = "/webserial");
@@ -33,45 +33,8 @@ public:
 
     // Print
 
-    void print(String m = "");
-
-    void print(const char *m);
-
-    void print(char *m);
-
-    void print(int m);
-
-    void print(uint8_t m);
-
-    void print(uint16_t m);
-
-    void print(uint32_t m);
-
-    void print(double m);
-
-    void print(float m);
-
-
-    // Print with New Line
-
-    void println(String m = "");
-
-    void println(const char *m);
-
-    void println(char *m);
-
-    void println(int m);
-
-    void println(uint8_t m);
-
-    void println(uint16_t m);
-
-    void println(uint32_t m);
-
-    void println(float m);
-
-    void println(double m);
-
+    size_t write(uint8_t);
+    size_t write(const uint8_t* buffer, size_t size);
 
 private:
     AsyncWebServer *_server;


### PR DESCRIPTION
Inherit from Arduino Print class.

This fixes Issue #55 (cannot do WebSerial.print(WiFi.localIP()) and possibly Issue #53 (memory leak)
It also allows WebSerial.print(millis()) which otherwise fails.
And allows WebSerial.printf(.....)