### PR TITLE
WebSerial.cpp: fixing warnings: `[-Wunused-parameter]`

### DIFF
--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -13,6 +13,11 @@ void WebSerialClass::begin(AsyncWebServer *server, const char* url){
     });
 
     _ws->onEvent([&](AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len) -> void {
+        // fix warnings: [-Wunused-parameter]
+        static_cast<void>(server);
+        static_cast<void>(client);
+        static_cast<void>(arg);
+
         if(type == WS_EVT_CONNECT){
             #if defined(DEBUG)
                 DEBUG_WEB_SERIAL("Client connection received");


### PR DESCRIPTION
They appear when the code is compiled with a flag `Wextra`.

I know of 3 possible solutions:
* A.) `static_cast<void>(unusedParameter);` – the one I chose
* B.) `(void) unusedParameter;` – "old" C–style casting, but `A` is more precise in C++
* C.) remove `unusedParameter` var from the function arguments – but keeping the name better explains what it is