### PR TITLE
feat: add end() function

### DIFF
--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -40,7 +40,6 @@ void WebSerialClass::begin(AsyncWebServer *server, const char* url){
 
 void WebSerialClass::end(){
     _server->removeHandler(_ws);
-    _ws->stop();
     delete _ws;
     #if defined(WEBSERIAL_DEBUG)
         DEBUG_WEB_SERIAL("Detached AsyncWebServer along with Websockets");

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -38,6 +38,15 @@ void WebSerialClass::begin(AsyncWebServer *server, const char* url){
     #endif
 }
 
+void WebSerialClass::end(){
+    _server->removeHandler(_ws);
+    _ws->stop();
+    delete _ws;
+    #if defined(WEBSERIAL_DEBUG)
+        DEBUG_WEB_SERIAL("Detached AsyncWebServer along with Websockets");
+    #endif
+}
+
 void WebSerialClass::msgCallback(RecvMsgHandler _recv){
     _RecvFunc = _recv;
 }

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -29,6 +29,8 @@ class WebSerialClass : public Print {
 public:
     void begin(AsyncWebServer *server, const char* url = "/webserial");
 
+    void end();
+
     void msgCallback(RecvMsgHandler _recv);
 
     // Print


### PR DESCRIPTION
this PR adds a "end()" method to the WebSerial class.
this way one can terminate the WebSerial instance when its no longer needed.