### PR TITLE
Code cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/esphome-ESPAsyncTCP#v2.0.0
 
       - name: Install ESPAsyncWebServer
-        run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/ESPAsyncWebServer#v2.10.1
+        run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/ESPAsyncWebServer#v2.10.4
 
       - name: Build Demo
         run: arduino-cli compile --library . --warnings none -b ${{ matrix.board }} "examples/Demo/Demo.ino"

--- a/examples/Demo_AP/Demo_AP.ino
+++ b/examples/Demo_AP/Demo_AP.ino
@@ -42,10 +42,10 @@ void setup() {
   WiFi.softAP(ssid, password);
   // Once connected, print IP
   Serial.print("IP Address: ");
-  Serial.println(WiFi.localIP());
+  Serial.println(WiFi.softAPIP());
 
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send(200, "text/plain", "Hi! This is WebSerial demo. You can access webserial interface at http://" + WiFi.localIP().toString() + "/webserial");
+    request->send(200, "text/plain", "Hi! This is WebSerial demo. You can access webserial interface at http://" + WiFi.softAPIP().toString() + "/webserial");
   });
 
   // WebSerial is accessible at "<IP Address>/webserial" in browser
@@ -72,7 +72,7 @@ void loop() {
   // Print every 2 seconds (non-blocking)
   if ((unsigned long)(millis() - last_print_time) > 2000) {
     WebSerial.print(F("IP address: "));
-    WebSerial.println(WiFi.localIP());
+    WebSerial.println(WiFi.softAPIP());
     WebSerial.printf("Uptime: %lums\n", millis());
     WebSerial.printf("Free heap: %u\n", ESP.getFreeHeap());
     last_print_time = millis();

--- a/library.json
+++ b/library.json
@@ -22,7 +22,7 @@
     {
       "owner": "mathieucarbou",
       "name": "ESP Async WebServer",
-      "version": "^2.10.1",
+      "version": "^2.10.4",
       "platforms": ["espressif8266", "espressif32"]
     }
   ]

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@ build_flags =
   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
 lib_deps = 
   mathieucarbou/Async TCP @ ^3.1.4
-  mathieucarbou/ESP Async WebServer @ 2.10.1
+  mathieucarbou/ESP Async WebServer @ 2.10.4
 upload_protocol = esptool
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, log2file
@@ -35,5 +35,5 @@ board = esp32-s3-devkitc-1
 platform = espressif8266
 board = huzzah
 lib_deps = 
-  mathieucarbou/ESP Async WebServer @ 2.10.1
+  mathieucarbou/ESP Async WebServer @ 2.10.4
   esphome/ESPAsyncTCP-esphome @ 2.0.0


### PR DESCRIPTION
- Typo
- String instead of fixed buffers for username/password
- setAuthentication(const String& username, const String& password)
- Bug in setAuthentication logic : empty strings were not checked
- Moving internal macros and enum in CPP file