### PR TITLE
Fix warnings and other little things

### DIFF
--- a/examples/Demo/Demo.ino
+++ b/examples/Demo/Demo.ino
@@ -81,7 +81,7 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
     WebSerial.printf("Uptime: %lums\n", millis());
-    WebSerial.printf("Free heap: %u\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap: %" PRIu32 "\n", ESP.getFreeHeap());
     last_print_time = millis();
   }
 

--- a/examples/Demo_AP/Demo_AP.ino
+++ b/examples/Demo_AP/Demo_AP.ino
@@ -74,7 +74,7 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.softAPIP());
     WebSerial.printf("Uptime: %lums\n", millis());
-    WebSerial.printf("Free heap: %u\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap: %" PRIu32 "\n", ESP.getFreeHeap());
     last_print_time = millis();
   }
 

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -83,7 +83,7 @@ size_t WebSerialClass::write(uint8_t m) {
 }
 
 // Println / Printf / Write func
-size_t WebSerialClass::write(uint8_t* buffer, size_t size) {
+size_t WebSerialClass::write(const uint8_t* buffer, size_t size) {
   loop();
   _wait_for_print_mutex();
   _print_buffer_mutex = true;

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -15,6 +15,9 @@ typedef enum {
   WSL_PONG = 0x04,
 } WSLPacketType;
 
+static const uint8_t WSL_PONG_MSG[] = {WSL_MAGIC_BYTE_1, WSL_MAGIC_BYTE_2, WSLPacketType::WSL_PONG};
+static const size_t WSL_PONG_MSG_LEN = sizeof(WSL_PONG_MSG) / sizeof(WSL_PONG_MSG[0]);
+
 void WebSerialClass::setAuthentication(const String& username, const String& password){
   _username = username;
   _password = password;
@@ -60,8 +63,7 @@ void WebSerialClass::begin(AsyncWebServer *server, const char* url) {
           }
         } else if (data[2] == WSLPacketType::WSL_PING) {
           // Send pong
-          uint8_t pong[] = {WSL_MAGIC_BYTE_1, WSL_MAGIC_BYTE_2, WSLPacketType::WSL_PONG};
-          client->binary(pong, sizeof(pong) / sizeof(pong[0]));
+          client->binary(WSL_PONG_MSG, WSL_PONG_MSG_LEN);
         }
       }
     }

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -227,7 +227,7 @@ void WebSerialClass::_flush_global_buffer() {
 void WebSerialClass::loop() {
   if ((unsigned long)(millis() - _last_cleanup_time) > WSL_CLEANUP_TIME_MS) {
     _last_cleanup_time = millis();
-    _ws->cleanupClients();
+    _ws->cleanupClients(WSL_MAX_WS_CLIENTS);
   }
 
   // If FLUSH_TIME ms has been passed since last packet time, flush logs

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -76,6 +76,21 @@ void WebSerialClass::onMessage(WSLMessageHandler recv) {
   _recv = recv;
 }
 
+void WebSerialClass::onMessage(WSLStringMessageHandler callback) {
+  _recv = [&](uint8_t *data, size_t len) {
+    if(data && len) {
+#ifdef ESP8266
+      String msg;
+      msg.reserve(len);
+      msg.concat((char*)data, len);
+      callback(msg);
+#else
+      callback(String((char*)data, len));
+#endif
+    }
+  };
+}
+
 // Print func
 size_t WebSerialClass::write(uint8_t m) {
   write(&m, 1);

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -118,10 +118,11 @@ class WebSerialClass : public Print {
     bool _has_enough_space(size_t size);
     size_t _start_row();
     size_t _write_row(uint8_t *data, size_t len);
-    size_t _write_row_packet(uint64_t reserved1, uint8_t reserved2, const uint8_t *payload, const size_t payload_size);
     size_t _end_row();
     void _flush_print_buffer();
     void _flush_global_buffer();
+
+    static size_t _write_row_packet(uint8_t* dest, const uint8_t *payload, size_t payload_size);
 };
 
 extern WebSerialClass WebSerial;

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -80,8 +80,8 @@ class WebSerialClass : public Print {
     inline void setAuthentication(const char* username, const char* password) { setAuthentication(String(username), String(password)); }
     void setAuthentication(const String& username, const String& password);
     void onMessage(WSLMessageHandler recv);
-    size_t write(uint8_t);
-    size_t write(uint8_t* buffer, size_t size);
+    size_t write(uint8_t) override;
+    size_t write(const uint8_t* buffer, size_t size) override;
     void loop();
 
   private:

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -35,6 +35,10 @@ License: AGPL-3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
     #include "ESPAsyncWebServer.h"
 #endif
 
+#ifndef WSL_MAX_WS_CLIENTS
+#define WSL_MAX_WS_CLIENTS DEFAULT_MAX_WS_CLIENTS
+#endif
+
 // Global buffer ( buffers all packets )
 #ifndef WSL_BUFFER_SIZE
 #define WSL_BUFFER_SIZE                       2048

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -77,6 +77,7 @@ License: AGPL-3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
 #endif
 
 typedef std::function<void(uint8_t *data, size_t len)> WSLMessageHandler;
+typedef std::function<void(const String& msg)> WSLStringMessageHandler;
 
 class WebSerialClass : public Print {
   public:
@@ -84,6 +85,7 @@ class WebSerialClass : public Print {
     inline void setAuthentication(const char* username, const char* password) { setAuthentication(String(username), String(password)); }
     void setAuthentication(const String& username, const String& password);
     void onMessage(WSLMessageHandler recv);
+    void onMessage(WSLStringMessageHandler recv);
     size_t write(uint8_t) override;
     size_t write(const uint8_t* buffer, size_t size) override;
     void loop();


### PR DESCRIPTION
On Arduino 3, type definition has changed. It is recommended to use PRIu32 / PRId32 / PRIu16 / PRId16 / etc for printf formats