### PR TITLE
Fix callback ref not kept when using WSLStringMessageHandler

### DIFF
--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -101,16 +101,13 @@ void WebSerialClass::onMessage(WSLMessageHandler recv) {
 }
 
 void WebSerialClass::onMessage(WSLStringMessageHandler callback) {
+  _recvString = callback;
   _recv = [&](uint8_t *data, size_t len) {
     if(data && len) {
-#ifdef ESP8266
       String msg;
       msg.reserve(len);
       msg.concat((char*)data, len);
-      callback(msg);
-#else
-      callback(String((char*)data, len));
-#endif
+      _recvString(msg);
     }
   };
 }

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -119,6 +119,7 @@ class WebSerialClass : public Print {
     AsyncWebServer *_server;
     AsyncWebSocket *_ws;
     WSLMessageHandler _recv = nullptr;
+    WSLStringMessageHandler _recvString = nullptr;
     bool _authenticate = false;
     String _username;
     String _password;


### PR DESCRIPTION
@ayushsharma82 : I tested the new release (2.0.4) today in the app requiring command history. Command history works fine, but I saw I introduced a bug when adding the `WSLStringMessageHandler`: the ref to the callback was not kept, so if the user was using an anonymous callback, it was dereferenced and the ESP crash.

The Pro version is affected too.

I tested this fix and it works.

Existing users won't see the bug if they keep a ref on their callback (and do not use anonymous callbacks).