### PR TITLE
chore: add connect/disconnect callbacks

### DIFF
--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -73,7 +73,20 @@ void WebSerialClass::begin(AsyncWebServer *server, const char* url) {
     // } else if(type == WS_EVT_DATA){
     if (type == WS_EVT_CONNECT) {
       client->setCloseClientOnQueueFull(false);
+      if(_onConnect != nullptr){
+        _onConnect();
+      }
+      if(_onClientConnect != nullptr){
+        _onClientConnect(client);
+      }
       return;
+    } else if(type == WS_EVT_DISCONNECT){
+      if(_onDisconnect != nullptr){
+        _onDisconnect();
+      }
+      if(_onClientDisconnect != nullptr){
+        _onClientDisconnect(client);
+      }
     }
     if(type == WS_EVT_DATA){
       // Detect magic bytes
@@ -112,6 +125,24 @@ void WebSerialClass::onMessage(WSLStringMessageHandler callback) {
       _recvString(msg);
     }
   };
+}
+
+// onConnect Callback Handler
+void WebSerialClass::onConnect(WSLConnectHandler onConnect) {
+  _onConnect = onConnect;
+}
+
+void WebSerialClass::onConnect(WSLClientConnectHandler onConnect) {
+  _onClientConnect = onConnect;
+}
+
+// onDisconnect Callback Handler
+void WebSerialClass::onDisconnect(WSLConnectHandler onDisconnect) {
+  _onDisconnect = onDisconnect;
+}
+
+void WebSerialClass::onDisconnect(WSLClientConnectHandler onDisconnect) {
+  _onClientDisconnect = onDisconnect;
 }
 
 // Print func

--- a/src/WebSerial.h
+++ b/src/WebSerial.h
@@ -89,6 +89,8 @@ License: AGPL-3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
 
 typedef std::function<void(uint8_t *data, size_t len)> WSLMessageHandler;
 typedef std::function<void(const String& msg)> WSLStringMessageHandler;
+typedef std::function<void()> WSLConnectHandler;
+typedef std::function<void(AsyncWebSocketClient* client)> WSLClientConnectHandler;
 
 class WebSerialClass : public Print {
   public:
@@ -97,6 +99,10 @@ class WebSerialClass : public Print {
     void setAuthentication(const String& username, const String& password);
     void onMessage(WSLMessageHandler recv);
     void onMessage(WSLStringMessageHandler recv);
+    void onConnect(WSLConnectHandler callback);
+    void onConnect(WSLClientConnectHandler callback);
+    void onDisconnect(WSLConnectHandler callback);
+    void onDisconnect(WSLClientConnectHandler callback);
     size_t write(uint8_t) override;
     size_t write(const uint8_t* buffer, size_t size) override;
     
@@ -143,6 +149,10 @@ class WebSerialClass : public Print {
     AsyncWebSocket *_ws;
     WSLMessageHandler _recv = nullptr;
     WSLStringMessageHandler _recvString = nullptr;
+    WSLConnectHandler _onConnect = nullptr;
+    WSLClientConnectHandler _onClientConnect = nullptr;
+    WSLConnectHandler _onDisconnect = nullptr;
+    WSLClientConnectHandler _onClientDisconnect = nullptr;
     bool _authenticate = false;
     String _username;
     String _password;


### PR DESCRIPTION
Implements #44

So you can do sth. like this:
```
webSerial.onConnect([]() {
  instance->webSerial.println("Hello client, I am the server!");
});
```

The callbacks work fine, but there seems to be bug causing messages that are sent to the client to only show up when you manually send messages from the client to the server. Not sure what that is all about. Maybe someone else would be kind enough to give it a try.